### PR TITLE
Use StringBuilder instead of synchronized StringBuffer

### DIFF
--- a/src/impl/krati/core/array/SimpleDataArrayCompactor.java
+++ b/src/impl/krati/core/array/SimpleDataArrayCompactor.java
@@ -464,7 +464,7 @@ class SimpleDataArrayCompactor implements Runnable
         
         public String toString()
         {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             
             buf.append(getClass().getSimpleName());
             buf.append("{index=");

--- a/src/impl/krati/core/array/basic/ArrayFile.java
+++ b/src/impl/krati/core/array/basic/ArrayFile.java
@@ -170,7 +170,7 @@ public class ArrayFile
   
   private String getHeader()
   {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     
     buf.append("version=");
     buf.append(_version);

--- a/src/impl/krati/core/segment/AbstractSegment.java
+++ b/src/impl/krati/core/segment/AbstractSegment.java
@@ -71,7 +71,7 @@ public abstract class AbstractSegment implements Segment
     
     protected String getHeader()
     {
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         
         b.append("lastForcedTime");
         b.append('=');
@@ -94,7 +94,7 @@ public abstract class AbstractSegment implements Segment
     @Override
     public String getStatus()
     {
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         
         b.append("loadSize");
         b.append('=');

--- a/src/impl/krati/store/AbstractDataArray.java
+++ b/src/impl/krati/store/AbstractDataArray.java
@@ -73,7 +73,7 @@ public abstract class AbstractDataArray implements DataArray, Persistable {
     
     public String getStatus()
     {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         
         buffer.append("path");
         buffer.append("=");

--- a/src/impl/krati/store/DynamicDataSet.java
+++ b/src/impl/krati/store/DynamicDataSet.java
@@ -714,7 +714,7 @@ public class DynamicDataSet implements DataSet<byte[]>
      */
     public String getStatus()
     {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         
         buf.append("level=");
         buf.append(_level);

--- a/src/impl/krati/store/DynamicDataStore.java
+++ b/src/impl/krati/store/DynamicDataStore.java
@@ -693,7 +693,7 @@ public class DynamicDataStore implements DataStore<byte[], byte[]>
      */
     public String getStatus()
     {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         
         buf.append("level=");
         buf.append(_level);

--- a/src/impl/krati/store/StaticArrayStorePartition.java
+++ b/src/impl/krati/store/StaticArrayStorePartition.java
@@ -221,7 +221,7 @@ public class StaticArrayStorePartition implements ArrayStorePartition
     
     protected String getStatus()
     {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         
         buffer.append("idStart");
         buffer.append("=");

--- a/src/impl/krati/util/Chronos.java
+++ b/src/impl/krati/util/Chronos.java
@@ -83,7 +83,7 @@ public class Chronos
    */
   public String getElapsedTime()
   {
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append(tick());
     sb.append(" ms");
     

--- a/test/src/test/code/TieredDataStore.java
+++ b/test/src/test/code/TieredDataStore.java
@@ -756,7 +756,7 @@ public class TieredDataStore implements DataStore<byte[], byte[]>
      */
     public String getStatus()
     {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         
         buf.append("level=");
         buf.append(_level);


### PR DESCRIPTION
This should be uncontroversial, the methods in StringBuffer are synchronized and StringBuilder should be used unless thread-safety is required.
