### PR TITLE
OSGi Bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ eclipse-build
 target
 docs
 logs
+
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.sna-projects.krati</groupId>
   <artifactId>krati</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <version>0.3.9-SNAPSHOT</version>
   <name>krati</name>
   <description>A hash-based high-performance data store</description>
@@ -155,6 +155,18 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.3.4</version>
+          <extensions>true</extensions>
+          <configuration>
+              <instructions>
+                  <Bundle-SymbolicName>com.sna-projects.krati</Bundle-SymbolicName>
+              </instructions>
+          </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Hi Jingwei,

I've included a couple of patches in this pull request, both of which should be pretty innocuous.
1. I'd like to use Krati as an OSGi bundle, and I've made some changes to the pom to use the apache felix bundler plugin to do so. This should have no effect on the final jar file other than adding a few lines to the MANIFEST.MF file.
2. Some trivial changes to the .gitignore file to ignore IntelliJ IDEA project files.

Oh, and thanks for all your hard work on Krati, it's working out really well on my current project.

Thanks,

Rob Lally.
